### PR TITLE
Integrate Vue Vben admin placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,9 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Admin Panel
+
+This project integrates [Vue Vben Admin](https://github.com/vbenjs/vue-vben-admin) as the Jetstream UI. The admin source code should be placed in `frontend/admin`.
+
+Refer to `frontend/admin/README.md` for setup instructions.

--- a/frontend/admin/README.md
+++ b/frontend/admin/README.md
@@ -1,0 +1,52 @@
+# Vue Vben Admin Integration
+
+This folder is intended for the [Vue Vben Admin](https://github.com/vbenjs/vue-vben-admin) codebase. The admin panel can be used as the UI for the Jetstream-powered Laravel backend.
+
+To get started:
+
+1. Clone the Vben admin project into this directory:
+
+   ```bash
+   git clone https://github.com/vbenjs/vue-vben-admin.git frontend/admin
+   ```
+
+2. Install the dependencies and run the development server:
+
+   ```bash
+   cd frontend/admin
+   pnpm install # or yarn / npm install
+   pnpm dev
+   ```
+
+3. Update `vite.config.js` to also build the admin panel. A simplified example:
+
+   ```js
+   import { defineConfig } from 'vite';
+   import laravel from 'laravel-vite-plugin';
+   import vue from '@vitejs/plugin-vue';
+
+   export default defineConfig({
+       plugins: [
+           laravel({
+               input: [
+                   'resources/js/app.js',
+                   'frontend/admin/src/main.ts',
+               ],
+               refresh: true,
+           }),
+           vue(),
+       ],
+   });
+   ```
+
+4. Create a route in `routes/web.php` that serves the admin panel:
+
+   ```php
+   Route::get('/admin/{any?}', fn () => view('admin'))
+       ->where('any', '.*')
+       ->middleware(['auth']);
+   ```
+
+5. Add a `resources/views/admin.blade.php` that loads the compiled assets (from `public/build` by default) and mounts the admin Vue application.
+
+This setup allows the Jetstream backend (authentication, teams, etc.) to be accessed by the Vue Vben Admin frontend.

--- a/resources/views/admin.blade.php
+++ b/resources/views/admin.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Admin Panel</title>
+        @vite('frontend/admin/src/main.ts')
+    </head>
+    <body>
+        <div id="app"></div>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,11 @@ Route::middleware([
     Route::get('/dashboard', function () {
         return Inertia::render('Dashboard');
     })->name('dashboard');
+
+    // Serve the Vue Vben Admin panel
+    Route::get('/admin/{any?}', function () {
+        return view('admin');
+    })->where('any', '.*');
 });
 
 Route::middleware(['auth'])->group(function () {

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,10 @@ import vue from '@vitejs/plugin-vue';
 export default defineConfig({
     plugins: [
         laravel({
-            input: 'resources/js/app.js',
+            input: [
+                'resources/js/app.js',
+                'frontend/admin/src/main.ts',
+            ],
             ssr: 'resources/js/ssr.js',
             refresh: true,
         }),


### PR DESCRIPTION
## Summary
- add instructions for using Vue Vben Admin in `frontend/admin`
- wire up route `/admin` and placeholder blade file
- update Vite config to build admin assets
- note admin integration in project README

## Testing
- `composer test` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68853755e9ec8331a702c435e451addf